### PR TITLE
Changes emitMap method to protected so that the emitter can be extensible for JVM languages

### DIFF
--- a/src/main/java/com/cognitect/transit/impl/AbstractEmitter.java
+++ b/src/main/java/com/cognitect/transit/impl/AbstractEmitter.java
@@ -116,7 +116,7 @@ public abstract class AbstractEmitter implements Emitter//, WriteHandler
             emitTagged(t, h.rep(o), asMapKey, cache);
     }
 
-    abstract void emitMap(Iterable<Map.Entry<Object, Object>> i, boolean ignored, WriteCache cache) throws Exception;
+    abstract protected void emitMap(Iterable<Map.Entry<Object, Object>> i, boolean ignored, WriteCache cache) throws Exception;
 
     protected void emitArray(Object o, boolean ignored, WriteCache cache) throws Exception {
 


### PR DESCRIPTION
Currently, write handlers must be in the Map<Class, WriteHandler<?, ?>> type object. However, classes defined in Ruby are all RubyClass type on Java side. This Map definition is unable to see the difference between Person and Point classes defined in Ruby code.  The solution would be override the logic to find the right handler.

The emitMap method is abstract and scope is a package local, which makes unable to extend. This small pull request changes it to protected and makes it extensible.
