### PR TITLE
convert AbstractParser.dateTimeFormat to a thread-local

### DIFF
--- a/src/main/java/com/cognitect/transit/impl/AbstractParser.java
+++ b/src/main/java/com/cognitect/transit/impl/AbstractParser.java
@@ -14,11 +14,18 @@ import java.util.Map;
 
 public abstract class AbstractParser implements Parser {
 
-    public static final SimpleDateFormat dateTimeFormat;
-    static {
-        dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        dateTimeFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+    private static final ThreadLocal<SimpleDateFormat> dateTimeFormat = new ThreadLocal<SimpleDateFormat>();
+
+    public static SimpleDateFormat getDateTimeFormat() {
+	SimpleDateFormat format = dateTimeFormat.get();
+	if (format == null) {
+	    format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+	    format.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+	    dateTimeFormat.set(format);
+	}
+	return format;
     }
+
 
     protected final Map<String, ReadHandler<?,?>> handlers;
     private final DefaultReadHandler<?> defaultHandler;

--- a/src/main/java/com/cognitect/transit/impl/WriteHandlers.java
+++ b/src/main/java/com/cognitect/transit/impl/WriteHandlers.java
@@ -342,7 +342,7 @@ public class WriteHandlers {
                 }
 
                 @Override
-                public String rep(Date o) { return AbstractParser.dateTimeFormat.format(o); }
+                public String rep(Date o) { return AbstractParser.getDateTimeFormat().format(o); }
 
                 @Override
                 public String stringRep(Date o) {

--- a/src/test/java/com/cognitect/transit/TransitMPTest.java
+++ b/src/test/java/com/cognitect/transit/TransitMPTest.java
@@ -148,7 +148,7 @@ public class TransitMPTest extends TestCase {
 
         Date d = new Date();
         final long t = d.getTime();
-        String timeString = JsonParser.dateTimeFormat.format(d);
+        String timeString = JsonParser.getDateTimeFormat().format(d);
 
         assertEquals(t, readTimeString(timeString));
 
@@ -265,7 +265,7 @@ public class TransitMPTest extends TestCase {
     public void testReadArrayWithNested() throws IOException {
 
         Date d = new Date();
-        final String t = JsonParser.dateTimeFormat.format(d);
+        final String t = JsonParser.getDateTimeFormat().format(d);
 
         List thing = new ArrayList() {{
             add("~:foo");
@@ -287,10 +287,10 @@ public class TransitMPTest extends TestCase {
                            new Date(1396909037000l)};
 
         List dates = new ArrayList() {{
-            add("~t" + JsonParser.dateTimeFormat.format(da[0]));
-            add("~t" + JsonParser.dateTimeFormat.format(da[1]));
-            add("~t" + JsonParser.dateTimeFormat.format(da[2]));
-            add("~t" + JsonParser.dateTimeFormat.format(da[3]));
+            add("~t" + JsonParser.getDateTimeFormat().format(da[0]));
+            add("~t" + JsonParser.getDateTimeFormat().format(da[1]));
+            add("~t" + JsonParser.getDateTimeFormat().format(da[2]));
+            add("~t" + JsonParser.getDateTimeFormat().format(da[3]));
         }};
 
         l = readerOf(dates).read();

--- a/src/test/java/com/cognitect/transit/TransitTest.java
+++ b/src/test/java/com/cognitect/transit/TransitTest.java
@@ -139,7 +139,7 @@ public class TransitTest extends TestCase {
 
         Date d = new Date();
         long t = d.getTime();
-        String timeString = JsonParser.dateTimeFormat.format(d);
+        String timeString = JsonParser.getDateTimeFormat().format(d);
 
         assertEquals(t, readTimeString(timeString));
 
@@ -218,7 +218,7 @@ public class TransitTest extends TestCase {
     public void testReadArrayWithNested() throws IOException {
 
         Date d = new Date();
-        String t = JsonParser.dateTimeFormat.format(d);
+        String t = JsonParser.getDateTimeFormat().format(d);
 
         List l = (List)reader("[\"~:foo\", \"~t" + t + "\", \"~?t\"]").read();
 
@@ -499,7 +499,7 @@ public class TransitTest extends TestCase {
     public void testWriteTime() throws Exception {
 
         Date d = new Date();
-        String dateString = AbstractParser.dateTimeFormat.format(d);
+        String dateString = AbstractParser.getDateTimeFormat().format(d);
         long dateLong = d.getTime();
         assertEquals(scalarVerbose("\"~t" + dateString + "\""), writeJsonVerbose(d));
         assertEquals(scalar("\"~m" + dateLong + "\""), writeJson(d));


### PR DESCRIPTION
Fixes #15 

This patch resolved the problem that we saw while invoking via `transit-clj`: I manually tested against old library and new, old consistently threw, new never threw.

However, I tried writing a multi-threaded test in Java, and could not reproduce the problem, even with 16 threads and 10k round-trip conversions. This leads me to believe that there is a deeper problem (or that I was just lucky, with multiple test runs never colliding).

I will continue to look at my test scenario, including trying to replicate the steps that the Clojure code was using (in particular, only doing a one-way conversion rather than a round-trip).