### PR TITLE
Stop caching stateful write handlers

### DIFF
--- a/src/main/java/com/cognitect/transit/TransitFactory.java
+++ b/src/main/java/com/cognitect/transit/TransitFactory.java
@@ -15,13 +15,10 @@
 package com.cognitect.transit;
 
 
-import com.cognitect.transit.SPI.ReaderSPI;
 import com.cognitect.transit.impl.*;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -251,13 +248,13 @@ public class TransitFactory {
     public static Map<String, ReadHandler<?,?>> defaultReadHandlers() { return ReaderFactory.defaultHandlers(); }
 
     /**
-     * Creates a read-only Map of String to ReadHandler containing default ReadHandlers
-     * with customHandlers merged in. Use this to build the collection of read handlers
-     * once, and pass it to repeated calls to TransitFactory.reader. This can be more
-     * efficient
-     * than repeatedly passing a map of custom handlers to TransitFactory.reader, which then
-     * merges them with the default handlers and/or looks them up in
-     * a cache each invocation.
+     * Creates a read-only Map of String to ReadHandler containing
+     * default ReadHandlers with customHandlers merged in. Use this to
+     * build the collection of read handlers once, and pass it to
+     * repeated calls to TransitFactory.reader. This can be more
+     * efficient than repeatedly passing a map of custom handlers to
+     * TransitFactory.reader, which then merges them with the default
+     * handlers and/or looks them up in a cache each invocation.
      * @param customHandlers a map of custom ReadHandlers to use in addition
      *                       or in place of the default ReadHandlers
      * @return a ReadHandlerMap
@@ -270,16 +267,18 @@ public class TransitFactory {
      * Returns a map of classes to Handlers that is used by default
      * @return class to Handler map
      */
-    public static Map<Class, WriteHandler<?,?>> defaultWriteHandlers() { return WriterFactory.defaultHandlers(); }
+    public static Map<Class, WriteHandler<?,?>> defaultWriteHandlers() {
+        return new WriteHandlerMap();
+    }
 
     /**
-     * Creates a read-only Map of String to WriteHandler containing default WriteHandlers
-     * with customHandlers merged in. Use this to build the collection of write handlers
-     * once, and pass it to repeated calls to TransitFactory.reader. This can be more
-     * than repeatedly passing a map of custom handlers to TransitFactory.writer, which then
-     * efficient
-     * merges them with the default handlers and/or looks them up in
-     * a cache each invocation.
+     * Creates a read-only Map of Class to WriteHandler containing
+     * default WriteHandlers with customHandlers merged in. Use this
+     * to build the collection of write handlers once, and pass it to
+     * repeated calls to TransitFactory.reader. This can be more
+     * efficient than repeatedly passing a map of custom handlers to
+     * TransitFactory.writer, which then merges them with the default
+     * handlers and/or looks them up in a cache each invocation.
      * @param customHandlers a map of custom WriteHandler to use in addition
      *                       or in place of the default WriteHandler
      * @return a WriteHandlerMap

--- a/src/main/java/com/cognitect/transit/impl/WriteHandlers.java
+++ b/src/main/java/com/cognitect/transit/impl/WriteHandlers.java
@@ -390,8 +390,7 @@ public class WriteHandlers {
         }
 
         @Override
-        public Object rep(UUID o) {
-            UUID uuid = (UUID)o;
+        public Object rep(UUID uuid) {
             long[] l = new long[2];
             l[0] = uuid.getMostSignificantBits();
             l[1] = uuid.getLeastSignificantBits();

--- a/src/main/java/com/cognitect/transit/impl/WriterFactory.java
+++ b/src/main/java/com/cognitect/transit/impl/WriterFactory.java
@@ -3,7 +3,8 @@
 
 package com.cognitect.transit.impl;
 
-import com.cognitect.transit.*;
+import com.cognitect.transit.WriteHandler;
+import com.cognitect.transit.Writer;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.msgpack.MessagePack;
@@ -11,99 +12,33 @@ import org.msgpack.packer.Packer;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.*;
+import java.util.Map;
 
 public class WriterFactory {
 
-    private static Map<Map<Class, WriteHandler<?,?>>, WriteHandlerMap> newHandlerCache = new Cache<Map<Class, WriteHandler<?,?>>, WriteHandlerMap>();
-    private static Map<Map<Class, WriteHandler<?,?>>, WriteHandlerMap> newVerboseHandlerCache = new Cache<Map<Class, WriteHandler<?,?>>, WriteHandlerMap>();
-
-
-    public static Map<Class, WriteHandler<?,?>> defaultHandlers() {
-
-        Map<Class, WriteHandler<?,?>> handlers = new HashMap<Class, WriteHandler<?,?>>();
-
-        WriteHandler integerHandler = new WriteHandlers.IntegerWriteHandler();
-        WriteHandler uriHandler = new WriteHandlers.ToStringWriteHandler("r");
-
-        handlers.put(Boolean.class, new WriteHandlers.BooleanWriteHandler());
-        handlers.put(null, new WriteHandlers.NullWriteHandler());
-        handlers.put(String.class, new WriteHandlers.ToStringWriteHandler("s"));
-        handlers.put(Integer.class, integerHandler);
-        handlers.put(Long.class, integerHandler);
-        handlers.put(Short.class, integerHandler);
-        handlers.put(Byte.class, integerHandler);
-        handlers.put(BigInteger.class, new WriteHandlers.ToStringWriteHandler("n"));
-        handlers.put(Float.class, new WriteHandlers.FloatWriteHandler());
-        handlers.put(Double.class, new WriteHandlers.DoubleWriteHandler());
-        handlers.put(Map.class, new WriteHandlers.MapWriteHandler());
-        handlers.put(BigDecimal.class, new WriteHandlers.ToStringWriteHandler("f"));
-        handlers.put(Character.class, new WriteHandlers.ToStringWriteHandler("c"));
-        handlers.put(Keyword.class, new WriteHandlers.KeywordWriteHandler());
-        handlers.put(Symbol.class, new WriteHandlers.ToStringWriteHandler("$"));
-        handlers.put(byte[].class, new WriteHandlers.BinaryWriteHandler());
-        handlers.put(UUID.class, new WriteHandlers.UUIDWriteHandler());
-        handlers.put(java.net.URI.class, uriHandler);
-        handlers.put(com.cognitect.transit.URI.class, uriHandler);
-        handlers.put(List.class, new WriteHandlers.ListWriteHandler());
-        handlers.put(Object[].class, new WriteHandlers.ArrayWriteHandler());
-        handlers.put(int[].class, new WriteHandlers.ArrayWriteHandler());
-        handlers.put(long[].class, new WriteHandlers.ArrayWriteHandler());
-        handlers.put(float[].class, new WriteHandlers.ArrayWriteHandler());
-        handlers.put(double[].class, new WriteHandlers.ArrayWriteHandler());
-        handlers.put(short[].class, new WriteHandlers.ArrayWriteHandler());
-        handlers.put(boolean[].class, new WriteHandlers.ArrayWriteHandler());
-        handlers.put(char[].class, new WriteHandlers.ArrayWriteHandler());
-        handlers.put(Set.class, new WriteHandlers.SetWriteHandler());
-        handlers.put(Date.class, new WriteHandlers.TimeWriteHandler());
-        handlers.put(Ratio.class, new WriteHandlers.RatioWriteHandler());
-        handlers.put(LinkImpl.class, new WriteHandlers.LinkWriteHandler());
-        handlers.put(Quote.class, new WriteHandlers.QuoteAbstractEmitter());
-        handlers.put(TaggedValue.class, new WriteHandlers.TaggedValueWriteHandler());
-        handlers.put(Object.class, new WriteHandlers.ObjectWriteHandler());
-
-        return handlers;
-    }
+    private static final Map<Map<Class, WriteHandler<?,?>>, WriteHandlerMap> handlerCache = new Cache<Map<Class, WriteHandler<?,?>>, WriteHandlerMap>();
 
     private static WriteHandlerMap handlerMap(Map<Class, WriteHandler<?, ?>> customHandlers) {
         if (customHandlers instanceof WriteHandlerMap)
-            return (WriteHandlerMap) customHandlers;
+            return new WriteHandlerMap(customHandlers);
 
-        if (newHandlerCache.containsKey(customHandlers)) {
-            return newHandlerCache.get(customHandlers);
+        if (handlerCache.containsKey(customHandlers)) {
+            return new WriteHandlerMap(handlerCache.get(customHandlers));
         }
 
-        synchronized (WriterFactory.class) {
-            if (newHandlerCache.containsKey(customHandlers)) {
-                return newHandlerCache.get(customHandlers);
+        synchronized (handlerCache) {
+            if (handlerCache.containsKey(customHandlers)) {
+                return new WriteHandlerMap(handlerCache.get(customHandlers));
             } else {
                 WriteHandlerMap writeHandlerMap = new WriteHandlerMap(customHandlers);
-                newHandlerCache.put(customHandlers, writeHandlerMap);
+                handlerCache.put(customHandlers, writeHandlerMap);
                 return writeHandlerMap;
             }
         }
     }
 
     private static WriteHandlerMap verboseHandlerMap(Map<Class, WriteHandler<?, ?>> customHandlers) {
-        if (customHandlers instanceof WriteHandlerMap) {
-            return ((WriteHandlerMap) customHandlers).verboseWriteHandlerMap();
-        }
-
-        if (newVerboseHandlerCache.containsKey(customHandlers)) {
-            return newVerboseHandlerCache.get(customHandlers);
-        }
-
-        synchronized (WriterFactory.class) {
-            if (newVerboseHandlerCache.containsKey(customHandlers)) {
-                return newVerboseHandlerCache.get(customHandlers);
-            } else {
-                WriteHandlerMap verboseHandlerMap = handlerMap(customHandlers).verboseWriteHandlerMap();
-                newVerboseHandlerCache.put(customHandlers, verboseHandlerMap);
-                return verboseHandlerMap;
-            }
-        }
+        return handlerMap(customHandlers).verboseWriteHandlerMap();
     }
 
     public static <T> Writer<T> getJsonInstance(final OutputStream out, Map<Class, WriteHandler<?,?>> customHandlers, boolean verboseMode) throws IOException {


### PR DESCRIPTION
This addresses #20 by caching only stateless handlers. With these changes, `WriteHandlerMaps`, which are stateful, are never reused across instances of `Writer`, though all of the stateless handlers are copied when a a call to e.g. `getJsonInstance` includes a `WriteHandlerMap` or just a `Map` of `Class` to `WriteHandler` (for custom write handlers).

- singleton instances of default stateless write handlers
- getJsonInstance always makes a new WriteHandlerMap
  - if you hand it nothing, it's got a copy of the defaults
  - if you hand it a customHandler map it merges its contents into a
    copy of defaults
  - if you hand it a merged WriteHandlerMap it pours its contents into a
    new WriteHandlerMap
- in each case, a new WriteHandlerMap gets a new MapWriteHandler and
  assigns itself as the tag provider