### PR TITLE
enable write handler for java.lang.Object

### DIFF
--- a/src/main/java/com/cognitect/transit/impl/WriteHandlerMap.java
+++ b/src/main/java/com/cognitect/transit/impl/WriteHandlerMap.java
@@ -199,7 +199,7 @@ public class WriteHandlerMap implements TagProvider, Map<Class, WriteHandler<?, 
     }
 
     private WriteHandler<?,?> checkBaseClasses(Class c) {
-        for(Class base = c.getSuperclass(); base != Object.class; base = base.getSuperclass()) {
+        for(Class base = c.getSuperclass(); base.getSuperclass() != null; base = base.getSuperclass()) {
             WriteHandler<?, ?> h = handlers.get(base);
             if(h != null) {
                 handlers.put(c, h);

--- a/src/main/java/com/cognitect/transit/impl/WriteHandlerMap.java
+++ b/src/main/java/com/cognitect/transit/impl/WriteHandlerMap.java
@@ -199,7 +199,7 @@ public class WriteHandlerMap implements TagProvider, Map<Class, WriteHandler<?, 
     }
 
     private WriteHandler<?,?> checkBaseClasses(Class c) {
-        for(Class base = c.getSuperclass(); base.getSuperclass() != null; base = base.getSuperclass()) {
+        for(Class base = c.getSuperclass(); base != null; base = base.getSuperclass()) {
             WriteHandler<?, ?> h = handlers.get(base);
             if(h != null) {
                 handlers.put(c, h);


### PR DESCRIPTION
current version does not allow for adding a generic handler for java.lang.Object. 
This however is desirable and would be tremendously useful when i just want to add a generic handler for objects that don't have a specific custom handler to prevent runtime exceptions ("java.lang.Exception: Not supported") whenever some new object sneaks onto the transit data.
Though an application should always sanitize the data before sending them over the wire (to make sure only 'serializable' data are sent), the application might not be aware of what transit handlers are currently supported. Sanitizing the data before handing them over to transit would  thus lead to handler duplication and tight coupling. 
By adding a generic handler for java.lang.Object a user can thus decide - e.g. for the remaining objects that don't have handler I want them serialized via nippy or converted to String etc.