### PR TITLE
Fix thread-safety issues in WriterFactory

### DIFF
--- a/src/main/java/com/cognitect/transit/impl/ReaderFactory.java
+++ b/src/main/java/com/cognitect/transit/impl/ReaderFactory.java
@@ -59,18 +59,13 @@ public class ReaderFactory {
             return customHandlers;
         }
 
-        if (handlerCache.containsKey(customHandlers)) {
-            return handlerCache.get(customHandlers);
-        }
-
         synchronized (ReaderFactory.class) {
-            if (handlerCache.containsKey(customHandlers)) {
-                return handlerCache.get(customHandlers);
-            } else {
-                ReadHandlerMap readHandlerMap = new ReadHandlerMap(customHandlers);
+            ReadHandlerMap readHandlerMap = handlerCache.get(customHandlers);
+            if (readHandlerMap == null) {
+                readHandlerMap = new ReadHandlerMap(customHandlers);
                 handlerCache.put(customHandlers, readHandlerMap);
-                return readHandlerMap;
             }
+            return readHandlerMap;
         }
     }
 

--- a/src/main/java/com/cognitect/transit/impl/ReaderFactory.java
+++ b/src/main/java/com/cognitect/transit/impl/ReaderFactory.java
@@ -60,7 +60,7 @@ public class ReaderFactory {
         }
 
         synchronized (ReaderFactory.class) {
-            ReadHandlerMap readHandlerMap = handlerCache.get(customHandlers);
+            ReadHandlerMap readHandlerMap = (ReadHandlerMap) handlerCache.get(customHandlers);
             if (readHandlerMap == null) {
                 readHandlerMap = new ReadHandlerMap(customHandlers);
                 handlerCache.put(customHandlers, readHandlerMap);

--- a/src/main/java/com/cognitect/transit/impl/WriterFactory.java
+++ b/src/main/java/com/cognitect/transit/impl/WriterFactory.java
@@ -22,19 +22,15 @@ public class WriterFactory {
         if (customHandlers instanceof WriteHandlerMap)
             return new WriteHandlerMap(customHandlers);
 
-        if (handlerCache.containsKey(customHandlers)) {
-            return new WriteHandlerMap(handlerCache.get(customHandlers));
-        }
-
+        WriteHandlerMap savedHandlerMap;
         synchronized (handlerCache) {
-            if (handlerCache.containsKey(customHandlers)) {
-                return new WriteHandlerMap(handlerCache.get(customHandlers));
-            } else {
-                WriteHandlerMap writeHandlerMap = new WriteHandlerMap(customHandlers);
-                handlerCache.put(customHandlers, writeHandlerMap);
-                return writeHandlerMap;
+            savedHandlerMap = handlerCache.get(customHandlers);
+            if (savedHandlerMap == null) {
+                savedHandlerMap = new WriteHandlerMap(customHandlers);
+                handlerCache.put(customHandlers, savedHandlerMap);
             }
         }
+        return new WriteHandlerMap(savedHandlerMap);
     }
 
     private static WriteHandlerMap verboseHandlerMap(Map<Class, WriteHandler<?, ?>> customHandlers) {


### PR DESCRIPTION
 - Don't use double checked locking. The underlying cache isn't thread safe, and even if it were, due to evictions unsynchronized access can result in calling `new WriteHandlerMap(null)`
 - Never return the `WriteHandlerMap` that gets stored in the cache. `WriteHandlerMap`s are effectively mutable which can cause exceptions if the returned copy gets mutated by a different thread while another writer is being created.

Example exception this fixes:
```
                                cognitect.transit/writer               transit.clj:  143
             com.cognitect.transit.TransitFactory.writer       TransitFactory.java:   62
com.cognitect.transit.impl.WriterFactory.getJsonInstance        WriterFactory.java:   52
     com.cognitect.transit.impl.WriterFactory.handlerMap        WriterFactory.java:   31
       com.cognitect.transit.impl.WriteHandlerMap.<init>      WriteHandlerMap.java:   83
                                java.util.HashMap.putAll              HashMap.java:  784
                         java.util.HashMap.putMapEntries              HashMap.java:  511
                    java.util.HashMap$EntryIterator.next              HashMap.java: 1469
                    java.util.HashMap$EntryIterator.next              HashMap.java: 1471
                 java.util.HashMap$HashIterator.nextNode              HashMap.java: 1437
java.util.ConcurrentModificationException:
               java.lang.RuntimeException: java.util.ConcurrentModificationException
```