### PR TITLE
Update msgpack

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["target/classes"]
  :deps
  {com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.0"}
-  org.msgpack/msgpack {:mvn/version "0.6.12"}
+  org.msgpack/msgpack-core {:mvn/version "0.9.11"}
   javax.xml.bind/jaxb-api {:mvn/version "2.3.0"}}
 
  :deps/prep-lib

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
     </dependency>
     <dependency>
       <groupId>org.msgpack</groupId>
-      <artifactId>msgpack</artifactId>
-      <version>0.6.12</version>
+      <artifactId>msgpack-core</artifactId>
+      <version>0.9.11</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/src/main/java/com/cognitect/transit/impl/MsgpackEmitter.java
+++ b/src/main/java/com/cognitect/transit/impl/MsgpackEmitter.java
@@ -4,7 +4,7 @@
 package com.cognitect.transit.impl;
 
 import com.cognitect.transit.WriteHandler;
-import org.msgpack.packer.Packer;
+import org.msgpack.core.MessagePacker;
 
 import java.io.IOException;
 import java.util.Map;
@@ -13,20 +13,20 @@ import java.util.Base64;
 
 public class MsgpackEmitter extends AbstractEmitter {
 
-    private final Packer gen;
+    private final MessagePacker gen;
 
     @Deprecated
-    public MsgpackEmitter(Packer gen, WriteHandlerMap writeHandlerMap) {
+    public MsgpackEmitter(MessagePacker gen, WriteHandlerMap writeHandlerMap) {
         super(writeHandlerMap, null);
         this.gen = gen;
     }
 
-    public MsgpackEmitter(Packer gen, WriteHandlerMap writeHandlerMap, WriteHandler defaultWriteHandler) {
+    public MsgpackEmitter(MessagePacker gen, WriteHandlerMap writeHandlerMap, WriteHandler defaultWriteHandler) {
         super(writeHandlerMap, defaultWriteHandler);
         this.gen = gen;
     }
 
-    public MsgpackEmitter(Packer gen, WriteHandlerMap writeHandlerMap, WriteHandler defaultWriteHandler, Function<Object,Object> transform) {
+    public MsgpackEmitter(MessagePacker gen, WriteHandlerMap writeHandlerMap, WriteHandler defaultWriteHandler, Function<Object,Object> transform) {
         super(writeHandlerMap, defaultWriteHandler, transform);
         this.gen = gen;
     }
@@ -38,23 +38,23 @@ public class MsgpackEmitter extends AbstractEmitter {
 
     @Override
     public void emitNil(boolean asMapKey, WriteCache cache) throws Exception {
-        this.gen.writeNil();
+        this.gen.packNil();
     }
 
 @Override
     public void emitString(String prefix, String tag, String s, boolean asMapKey, WriteCache cache) throws Exception {
         String outString = cache.cacheWrite(Util.maybePrefix(prefix, tag, s), asMapKey);
-        this.gen.write(outString);
+        this.gen.packString(outString);
     }
 
     @Override
     public void emitBoolean(Boolean b, boolean asMapKey, WriteCache cache) throws Exception {
-        this.gen.write(b);
+        this.gen.packBoolean(b);
     }
 
     @Override
     public void emitBoolean(boolean b, boolean asMapKey, WriteCache cache) throws Exception {
-        this.gen.write(b);
+        this.gen.packBoolean(b);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class MsgpackEmitter extends AbstractEmitter {
         long i = Util.numberToPrimitiveLong(o);
         if ((i > Long.MAX_VALUE) || (i < Long.MIN_VALUE))
             this.emitString(Constants.ESC_STR, "i", o.toString(), asMapKey, cache);
-        this.gen.write(i);
+        this.gen.packLong(i);
     }
 
 
@@ -70,28 +70,28 @@ public class MsgpackEmitter extends AbstractEmitter {
     public void emitInteger(long i, boolean asMapKey, WriteCache cache) throws Exception {
         if ((i > Long.MAX_VALUE) || (i < Long.MIN_VALUE))
             this.emitString(Constants.ESC_STR, "i", String.valueOf(i), asMapKey, cache);
-        this.gen.write(i);
+        this.gen.packLong(i);
     }
 
 
     @Override
     public void emitDouble(Object d, boolean asMapKey, WriteCache cache) throws Exception {
         if (d instanceof Double)
-            this.gen.write((Double) d);
+            this.gen.packDouble((Double) d);
         else if (d instanceof Float)
-            this.gen.write((Float) d);
+            this.gen.packFloat((Float) d);
         else
             throw new Exception("Unknown floating point type: " + d.getClass());
     }
 
     @Override
     public void emitDouble(float d, boolean asMapKey, WriteCache cache) throws Exception {
-        this.gen.write(d);
+        this.gen.packFloat(d);
     }
 
     @Override
     public void emitDouble(double d, boolean asMapKey, WriteCache cache) throws Exception {
-        this.gen.write(d);
+        this.gen.packDouble(d);
     }
 
     @Override
@@ -102,22 +102,22 @@ public class MsgpackEmitter extends AbstractEmitter {
 
     @Override
     public void emitArrayStart(Long size) throws Exception {
-        this.gen.writeArrayBegin(size.intValue());
+        this.gen.packArrayHeader(size.intValue());
     }
 
     @Override
     public void emitArrayEnd() throws Exception {
-        this.gen.writeArrayEnd();
+        // msgpack-core uses counted headers, no end marker needed
     }
 
     @Override
     public void emitMapStart(Long size) throws Exception {
-        this.gen.writeMapBegin(size.intValue());
+        this.gen.packMapHeader(size.intValue());
     }
 
     @Override
     public void emitMapEnd() throws Exception {
-        this.gen.writeMapEnd();
+        // msgpack-core uses counted headers, no end marker needed
     }
 
     @Override

--- a/src/main/java/com/cognitect/transit/impl/MsgpackParser.java
+++ b/src/main/java/com/cognitect/transit/impl/MsgpackParser.java
@@ -4,20 +4,21 @@
 package com.cognitect.transit.impl;
 
 import com.cognitect.transit.*;
-import org.msgpack.type.Value;
-import org.msgpack.type.ValueType;
-import org.msgpack.unpacker.Unpacker;
+import org.msgpack.core.MessageUnpacker;
+
+import org.msgpack.value.ValueType;
 
 import java.io.IOException;
-import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
 
 public class MsgpackParser extends AbstractParser {
-    private final Unpacker mp;
+    private final MessageUnpacker mp;
 
-    public MsgpackParser(Unpacker mp,
+    public MsgpackParser(MessageUnpacker mp,
                          Map<String, ReadHandler<?,?>> handlers,
                          DefaultReadHandler defaultHandler,
                          MapReader<?, Map<Object, Object>, Object, Object> mapBuilder,
@@ -27,16 +28,7 @@ public class MsgpackParser extends AbstractParser {
     }
 
     private Object parseLong() throws IOException {
-        Value val = mp.readValue();
-
-        try {
-            return val.asIntegerValue().getLong();
-        }
-        catch (Exception ex) {
-            BigInteger bi = new BigInteger(val.asRawValue().getString());
-        }
-
-        return val;
+        return mp.unpackLong();
     }
 
     @Override
@@ -46,21 +38,21 @@ public class MsgpackParser extends AbstractParser {
 
     @Override
     public Object parseVal(boolean asMapKey, ReadCache cache) throws IOException {
-        switch (mp.getNextType()) {
+        switch (mp.getNextFormat().getValueType()) {
             case MAP:
                 return parseMap(asMapKey, cache, null);
             case ARRAY:
                 return parseArray(asMapKey, cache, null);
-            case RAW:
-                return cache.cacheRead(mp.readValue().asRawValue().getString(), asMapKey, this);
+            case STRING:
+                return cache.cacheRead(mp.unpackString(), asMapKey, this);
             case INTEGER:
                 return parseLong();
             case FLOAT:
-                return mp.readValue().asFloatValue().getDouble();
+                return mp.unpackDouble();
             case BOOLEAN:
-                return mp.readValue().asBooleanValue().getBoolean();
+                return mp.unpackBoolean();
             case NIL:
-                mp.readNil();
+                mp.unpackNil();
         }
 
         return null;
@@ -69,7 +61,7 @@ public class MsgpackParser extends AbstractParser {
     @Override
     public Object parseMap(boolean ignored, ReadCache cache, MapReadHandler<Object, ?, Object, Object, ?> handler) throws IOException {
 
-	    int sz = this.mp.readMapBegin();
+	    int sz = this.mp.unpackMapHeader();
 
         MapReader<Object, ?, Object, Object> mr = (handler != null) ? handler.mapReader() : mapBuilder;
 
@@ -82,10 +74,10 @@ public class MsgpackParser extends AbstractParser {
                 ReadHandler<Object, Object> val_handler = getHandler(tag);
                 Object val;
                 if (val_handler != null) {
-                    if (this.mp.getNextType() == ValueType.MAP && val_handler instanceof MapReadHandler) {
+                    if (this.mp.getNextFormat().getValueType() == ValueType.MAP && val_handler instanceof MapReadHandler) {
                         // use map reader to decode value
                         val = parseMap(false, cache, (MapReadHandler<Object, ?, Object, Object, ?>) val_handler);
-                    } else if (this.mp.getNextType() == ValueType.ARRAY && val_handler instanceof ArrayReadHandler) {
+                    } else if (this.mp.getNextFormat().getValueType() == ValueType.ARRAY && val_handler instanceof ArrayReadHandler) {
                         // use array reader to decode value
                         val = parseArray(false, cache, (ArrayReadHandler<Object, ?, Object, ?>) val_handler);
                     } else {
@@ -97,21 +89,19 @@ public class MsgpackParser extends AbstractParser {
                     val = this.decode(tag, parseVal(false, cache));
                 }
 
-                this.mp.readMapEnd(true);
                 return val;
             } else {
                 mb = mr.add(mb, key, parseVal(false, cache));
             }
         }
 
-        this.mp.readMapEnd(true);
         return mr.complete(mb);
     }
 
     @Override
     public Object parseArray(boolean ignored, ReadCache cache, ArrayReadHandler<Object, ?, Object, ?> handler) throws IOException {
 
-	    int sz = this.mp.readArrayBegin();
+	    int sz = this.mp.unpackArrayHeader();
 
         ArrayReader<Object, ?, Object> ar = (handler != null) ? handler.arrayReader() : listBuilder;
 
@@ -124,10 +114,10 @@ public class MsgpackParser extends AbstractParser {
                 String tag = ((Tag) val).getValue();
                 ReadHandler<Object, Object> val_handler = getHandler(tag);
                 if (val_handler != null) {
-                    if (this.mp.getNextType() == ValueType.MAP && val_handler instanceof MapReadHandler) {
+                    if (this.mp.getNextFormat().getValueType() == ValueType.MAP && val_handler instanceof MapReadHandler) {
                         // use map reader to decode value
                         val = parseMap(false, cache, (MapReadHandler<Object, ?, Object, Object, ?>) val_handler);
-                    } else if (this.mp.getNextType() == ValueType.ARRAY && val_handler instanceof ArrayReadHandler) {
+                    } else if (this.mp.getNextFormat().getValueType() == ValueType.ARRAY && val_handler instanceof ArrayReadHandler) {
                         // use array reader to decode value
                         val = parseArray(false, cache, (ArrayReadHandler<Object, ?, Object, ?>) val_handler);
                     } else {
@@ -138,7 +128,6 @@ public class MsgpackParser extends AbstractParser {
                     // default decode
                     val = this.decode(tag, parseVal(false, cache));
                 }
-                this.mp.readArrayEnd();
                 return val;
             } else {
                 // fall through to regular parse
@@ -146,7 +135,6 @@ public class MsgpackParser extends AbstractParser {
             }
         }
 
-        this.mp.readArrayEnd();
         return ar.complete(ab);
     }
 }

--- a/src/main/java/com/cognitect/transit/impl/ReaderFactory.java
+++ b/src/main/java/com/cognitect/transit/impl/ReaderFactory.java
@@ -6,7 +6,7 @@ package com.cognitect.transit.impl;
 import com.cognitect.transit.*;
 import com.cognitect.transit.SPI.ReaderSPI;
 import com.fasterxml.jackson.core.JsonFactory;
-import org.msgpack.MessagePack;
+import org.msgpack.core.MessagePack;
 
 import java.io.InputStream;
 import java.util.HashMap;
@@ -154,8 +154,7 @@ public class ReaderFactory {
 
         @Override
         protected AbstractParser createParser() {
-            MessagePack mp = new MessagePack();
-            return new MsgpackParser(mp.createUnpacker(in), handlers, defaultHandler,
+            return new MsgpackParser(MessagePack.newDefaultUnpacker(in), handlers, defaultHandler,
                     mapBuilder, listBuilder);
         }
     }

--- a/src/main/java/com/cognitect/transit/impl/WriterFactory.java
+++ b/src/main/java/com/cognitect/transit/impl/WriterFactory.java
@@ -7,8 +7,8 @@ import com.cognitect.transit.WriteHandler;
 import com.cognitect.transit.Writer;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import org.msgpack.MessagePack;
-import org.msgpack.packer.Packer;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -61,7 +61,7 @@ public class WriterFactory {
 
     public static <T> Writer<T> getMsgpackInstance(final OutputStream out, Map<Class, WriteHandler<?,?>> customHandlers, WriteHandler<?, ?> defaultWriteHandler, Function<Object,Object> transform) throws IOException {
 
-        Packer packer = new MessagePack().createPacker(out);
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
 
         final MsgpackEmitter emitter = new MsgpackEmitter(packer, buildWriteHandlerMap(customHandlers), defaultWriteHandler, transform);
 

--- a/src/test/java/com/cognitect/transit/TransitMPTest.java
+++ b/src/test/java/com/cognitect/transit/TransitMPTest.java
@@ -20,8 +20,8 @@ import com.cognitect.transit.impl.WriteCache;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import org.msgpack.MessagePack;
-import org.msgpack.packer.Packer;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,16 +43,68 @@ public class TransitMPTest extends TestCase {
         return new TestSuite(TransitMPTest.class);
     }
 
+    // Needed to pack objects with the new msgpack-core API
+    private static void packObject(MessagePacker packer, Object o) throws IOException {
+        if (o == null) {
+            packer.packNil();
+        } else if (o instanceof String) {
+            packer.packString((String) o);
+        } else if (o instanceof Boolean) {
+            packer.packBoolean((Boolean) o);
+        } else if (o instanceof Integer) {
+            packer.packInt((Integer) o);
+        } else if (o instanceof Long) {
+            packer.packLong((Long) o);
+        } else if (o instanceof Double) {
+            packer.packDouble((Double) o);
+        } else if (o instanceof Float) {
+            packer.packFloat((Float) o);
+        } else if (o instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) o;
+            packer.packMapHeader(map.size());
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                packObject(packer, entry.getKey());
+                packObject(packer, entry.getValue());
+            }
+        } else if (o instanceof List) {
+            List<?> list = (List<?>) o;
+            packer.packArrayHeader(list.size());
+            for (Object item : list) {
+                packObject(packer, item);
+            }
+        } else if (o instanceof long[]) {
+            long[] arr = (long[]) o;
+            packer.packArrayHeader(arr.length);
+            for (long v : arr) {
+                packer.packLong(v);
+            }
+        } else if (o instanceof int[]) {
+            int[] arr = (int[]) o;
+            packer.packArrayHeader(arr.length);
+            for (int v : arr) {
+                packer.packInt(v);
+            }
+        } else if (o instanceof String[]) {
+            String[] arr = (String[]) o;
+            packer.packArrayHeader(arr.length);
+            for (String v : arr) {
+                packer.packString(v);
+            }
+        } else {
+            throw new IllegalArgumentException("Cannot pack object of type: " + o.getClass());
+        }
+    }
+
     // Reading
 
     public Reader readerOf(Object... things) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        MessagePack msgpack = new MessagePack();
-        Packer packer = msgpack.createPacker(out);
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
 
         for (Object o : things) {
-            packer.write(o);
+            packObject(packer, o);
         }
+        packer.flush();
 
         InputStream in = new ByteArrayInputStream(out.toByteArray());
         return TransitFactory.reader(TransitFactory.Format.MSGPACK, in);


### PR DESCRIPTION
# MsgpackEmitter.java

* The old API had `writeArrayEnd()` / `writeMapEnd()` that the emitter called.  msgpack-core has no end markers, so `emitArrayEnd()` and `emitMapEnd()` are now empty bodies. They're required by the Emitter interface which the JSON emitter still needs.

# MsgpackParser.java

* Calls to `readMapEnd(true)` and `readArrayEnd()` were removed entirely since the new API has no equivalent.
* `parseLong()` has been simplified so overflow now throws `MessageIntegerOverflowException` instead of the accidental` MessageTypeException`. It was accidental because a BigInteger result was created but never returned.
